### PR TITLE
contextual_model_bert: also return scores with predictions

### DIFF
--- a/src/common.py
+++ b/src/common.py
@@ -134,6 +134,16 @@ class ControllerBase:
 
         return best_dev_loss
 
+    def evaluate_single(self, document):
+        # doc_name: <cluster assignments> pairs for all test documents
+        logging.info("Evaluating a single document...")
+
+        predictions, _, probabilities = self._train_doc(document, eval_mode=True)
+        clusters = get_clusters(predictions)
+        scores = {m: probabilities[m] for m in clusters.keys()}
+
+        return { "predictions": predictions, "clusters": clusters, "scores": scores }
+
     @torch.no_grad()
     def evaluate(self, test_docs):
         # doc_name: <cluster assignments> pairs for all test documents

--- a/src/common.py
+++ b/src/common.py
@@ -90,7 +90,12 @@ class ControllerBase:
             for idx_doc in tqdm(shuffle_indices):
                 curr_doc = train_docs[idx_doc]
 
-                _, (doc_loss, n_examples) = self._train_doc(curr_doc)
+                res = self._train_doc(curr_doc)
+                # Some models additionally return probas, some do not
+                if len(res) == 3:
+                    _, (doc_loss, n_examples), _ = self._train_doc(curr_doc)
+                else:
+                    _, (doc_loss, n_examples) = self._train_doc(curr_doc)
 
                 train_loss += doc_loss
                 train_examples += n_examples
@@ -98,7 +103,12 @@ class ControllerBase:
             self.eval_mode()
             dev_loss, dev_examples = 0.0, 0
             for curr_doc in dev_docs:
-                _, (doc_loss, n_examples) = self._train_doc(curr_doc, eval_mode=True)
+                res = self._train_doc(curr_doc, eval_mode=True)
+                # Some models additionally return probas, some do not
+                if len(res) == 3:
+                    _, (doc_loss, n_examples), _ = self._train_doc(curr_doc)
+                else:
+                    _, (doc_loss, n_examples) = self._train_doc(curr_doc)
 
                 dev_loss += doc_loss
                 dev_examples += n_examples
@@ -138,7 +148,14 @@ class ControllerBase:
         # doc_name: <cluster assignments> pairs for all test documents
         logging.info("Evaluating a single document...")
 
-        predictions, _, probabilities = self._train_doc(document, eval_mode=True)
+        res = self._train_doc(document, eval_mode=True)
+
+        # Some models additionally return probas, some do not
+        if len(res) == 3:
+            predictions, _, probabilities = res
+        else:
+            predictions, _ = res
+
         clusters = get_clusters(predictions)
         scores = {m: probabilities[m] for m in clusters.keys()}
 

--- a/src/data.py
+++ b/src/data.py
@@ -105,9 +105,10 @@ class Token:
         self.position_in_sentence = position_in_sentence
         self.position_in_document = position_in_document
 
-        self.gender = self._extract_gender(msd)
-        self.number = self._extract_number(msd)
-        self.category = msd[0]
+        if msd is not None:
+            self.gender = self._extract_gender(msd)
+            self.number = self._extract_number(msd)
+            self.category = msd[0]
 
     def __str__(self):
         return f"Token(\"{self.raw_text}\")"


### PR DESCRIPTION
Main contribution: 

- `_train_doc` currently returns (antecedent?) predictions. Modification now also returns the probability of the chosen (most probable) antecedent for the current mention.

Misc contributions:

- added `evaluate_single` method to `ControllerBase` that evaluates one, given Document
- handle Token construction with `None` msd string.